### PR TITLE
default inputs and deps update

### DIFF
--- a/step.yml
+++ b/step.yml
@@ -22,17 +22,19 @@ is_skippable: false
 deps:
   brew:
   - name: awscli
+    bin_name: aws
   apt_get:
   - name: awscli
+    bin_name: aws
 run_if: ""
 inputs:
-  - access_key_id: ""
+  - access_key_id: "$AWS_ACCESS_KEY"
     opts:
       title: "AWS Access Key"
       summary: ""
       description: ""
       is_required: true
-  - secret_access_key: ""
+  - secret_access_key: "$AWS_SECRET_KEY"
     opts:
       title: "AWS Secret Key"
       summary: ""
@@ -94,7 +96,7 @@ inputs:
       title: "Build Number"
       description: "Build number"
       is_required: true
-  - aws_region: ""
+  - aws_region: "$AWS_REGION"
     opts:
       title: "AWS Region"
       summary: ""


### PR DESCRIPTION
Added the new `bin_name` property - available in Bitrise CLI 1.4.0 and newer ;) - http://blog.bitrise.io/2016/09/13/monthly-release-of-bitrise-cli-sept.html

and default input values - it's usually a good idea to define default values

1. for inputs which should be specified in Secrets, instead of directly for the input
2. for inputs which will be most likely reused in another step, so it's enough to define it once, either as an App Env Var or Secret