### PR TITLE
Wait for Device Farm builds to complete & return results

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -26,6 +26,8 @@ workflows:
         - android_pool: ""
         - run_name_prefix: "testscript"
         - aws_region: ""
+        - run_wait_for_results: true
+        - run_fail_on_warning: true
 
   # ----------------------------------------------------------------
   # --- workflow to Release with auto version bump
@@ -115,4 +117,3 @@ workflows:
                 cd "${collections_folder}/${newest_collection}/collection"
                 echo -ne "$STEP_ID_IN_STEPLIB $STEP_GIT_VERION_TAG_TO_SHARE\n\n" | cat - PULL_REQUEST_TEMPLATE.md | hub pull-request -b bitrise-io/bitrise-steplib:master -F -
             fi
-

--- a/step.sh
+++ b/step.sh
@@ -87,13 +87,13 @@ function validate_required_input_with_options {
 }
 
 function validate_ios_inputs {
-    validate_required_input "ipa_path" $ipa_path
-    validate_required_input "ios_pool" $ios_pool
+    validate_required_input "ipa_path" "${ipa_path}"
+    validate_required_input "ios_pool" "${ios_pool}"
 }
 
 function validate_android_inputs {
-    validate_required_input "apk_path" $apk_path
-    validate_required_input "android_pool" $android_pool
+    validate_required_input "apk_path" "${apk_path}"
+    validate_required_input "android_pool" "${android_pool}"
 }
 
 function get_test_package_arn {
@@ -106,7 +106,7 @@ function get_test_package_arn {
 
 function get_upload_status {
     local upload_arn="$1"
-    validate_required_variable "upload_arn" $upload_arn
+    validate_required_variable "upload_arn" "${upload_arn}"
 
     local upload_status=$(aws devicefarm get-upload --arn="$upload_arn" --query='upload.status' --output=text)
     echo "$upload_status"
@@ -114,7 +114,7 @@ function get_upload_status {
 
 function get_run_result {
     local run_arn="$1"
-    validate_required_variable "run_arn" $run_arn
+    validate_required_variable "run_arn" "${run_arn}"
 
     local run_result=$(aws devicefarm get-run --arn="$run_arn" --query='run.result' --output=text)
     echo "$run_result"
@@ -122,7 +122,7 @@ function get_run_result {
 
 function get_run_final_result {
     local run_arn="$1"
-    validate_required_variable "run_arn" $run_arn
+    validate_required_variable "run_arn" "${run_arn}"
 
     local run_final_details=$(aws devicefarm get-run --arn="$run_arn")
     local run_final_details_minutes=$(echo "${run_final_details}" | jq -r .run.deviceMinutes.total)
@@ -153,10 +153,10 @@ function device_farm_run {
     echo_details "* app_package_path: $app_package_path"
     echo_details "* upload_type: $upload_type"
 
-    validate_required_variable "test_package_arn" $test_package_arn
-    validate_required_variable "device_pool" $device_pool
-    validate_required_variable "app_package_path" $app_package_path
-    validate_required_variable "upload_type" $upload_type
+    validate_required_variable "test_package_arn" "${test_package_arn}"
+    validate_required_variable "device_pool" "${device_pool}"
+    validate_required_variable "app_package_path" "${app_package_path}"
+    validate_required_variable "upload_type" "${upload_type}"
 
     # Intialize upload
     local app_filename=$(basename "$app_package_path")
@@ -279,14 +279,14 @@ echo_details "* build_version: $build_version"
 echo_details "* aws_region: $aws_region"
 echo
 
-validate_required_input "access_key_id" $access_key_id
-validate_required_input "secret_access_key" $secret_access_key
-validate_required_input "device_farm_project" $device_farm_project
-validate_required_input "test_package_name" $test_package_name
-validate_required_input "test_type" $test_type
+validate_required_input "access_key_id" "${access_key_id}"
+validate_required_input "secret_access_key" "${secret_access_key}"
+validate_required_input "device_farm_project" "${device_farm_project}"
+validate_required_input "test_package_name" "${test_package_name}"
+validate_required_input "test_type" "${test_type}"
 
 options=("ios"  "android" "ios+android")
-validate_required_input_with_options "platform" $platform "${options[@]}"
+validate_required_input_with_options "platform" "${platform}" "${options[@]}"
 
 if [[ "$aws_region" != "" ]] ; then
     echo_details "AWS region (${aws_region}) specified!"

--- a/step.sh
+++ b/step.sh
@@ -4,6 +4,9 @@ THIS_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 set -e
 
+# Uncomment for easier debugging:
+#set -x
+
 #=======================================
 # Functions
 #=======================================

--- a/step.sh
+++ b/step.sh
@@ -124,7 +124,7 @@ function get_run_final_result {
     local run_arn="$1"
     validate_required_variable "run_arn" "${run_arn}"
 
-    local run_final_details=$(aws devicefarm get-run --arn="$run_arn")
+    local run_final_details=$(aws devicefarm get-run --arn="$run_arn" --output=json)
     local run_final_details_minutes=$(echo "${run_final_details}" | jq -r .run.deviceMinutes.total)
     local run_final_details_completed_jobs=$(echo "${run_final_details}" | jq -r .run.completedJobs)
     local run_final_details_total_jobs=$(echo "${run_final_details}" | jq -r .run.totalJobs)
@@ -196,7 +196,7 @@ function device_farm_run {
         run_params+=(--name="$run_name")
         echo_details "Using run name '$run_name'"
     fi
-    local run_response=$(aws devicefarm schedule-run "${run_params[@]}")
+    local run_response=$(aws devicefarm schedule-run "${run_params[@]}" --output=json)
     echo_info "Run started for $run_platform!"
     echo_details "Run response: '${run_response}'"
 

--- a/step.sh
+++ b/step.sh
@@ -128,7 +128,7 @@ function get_run_final_result {
     local run_final_details_minutes=$(echo "${run_final_details}" | jq -r .run.deviceMinutes.total)
     local run_final_details_completed_jobs=$(echo "${run_final_details}" | jq -r .run.completedJobs)
     local run_final_details_total_jobs=$(echo "${run_final_details}" | jq -r .run.totalJobs)
-    local run_final_details_summary="Run performed ${run_final_details_completed_jobs}/${run_final_details_total_jobs} jobs. Total time ${run_final_details_minutes} minutes."
+    local run_final_details_summary="Devicefarm performed ${run_final_details_completed_jobs}/${run_final_details_total_jobs} jobs. Total time ${run_final_details_minutes} minutes."
 
     # Output in build log
     echo_details "$run_final_details"

--- a/step.sh
+++ b/step.sh
@@ -131,8 +131,8 @@ function get_run_final_result {
     local run_final_details_summary="Run performed ${run_final_details_completed_jobs}/${run_final_details_total_jobs} jobs. Total time ${run_final_details_minutes} minutes."
 
     # Output in build log
-    echo_details $run_final_details
-    echo_details $run_final_details_summary
+    echo_details "$run_final_details"
+    echo_details "$run_final_details_summary"
 
     # Export results to be used in subsequent notification steps
     envman add --key BITRISE_DEVICEFARM_RESULTS_RAW --value "$run_final_details"

--- a/step.yml
+++ b/step.yml
@@ -25,9 +25,13 @@ deps:
   brew:
   - name: awscli
     bin_name: aws
+  - name: jq
+    bin_name: jq
   apt_get:
   - name: awscli
     bin_name: aws
+  - name: jq
+    bin_name: jq
 run_if: ""
 inputs:
   - access_key_id: "$AWS_ACCESS_KEY"

--- a/step.yml
+++ b/step.yml
@@ -112,6 +112,21 @@ inputs:
       description: |
         If you want to specify a different AWS region. Leave
         empty to use the default config/env setting.
+  - run_wait_for_results: "true"
+    opts:
+      title: "Whether or not to wait for the test results from Devicefarm"
+      description: |-
+          If set to true, the script waits for the test run to complete on
+          Devicefarm before returning success/failure. This will slow down your
+          Bitrise runs, however allows you to make decisions in subsequent steps
+          based on success/failure of the tests.
+  - run_fail_on_warning: "true"
+    opts:
+      title: "Fail if the DeviceFarm results return result of WARNED"
+      description: |-
+          Depending on your tests, you may or may not wish to fail the step if
+          DeviceFarm returns a WARNED result. Only takes effect if
+          run_wait_for_results is also enabled.
 outputs:
   - BITRISE_DEVICEFARM_RESULTS_RAW:
     opts:

--- a/step.yml
+++ b/step.yml
@@ -112,4 +112,14 @@ inputs:
       description: |
         If you want to specify a different AWS region. Leave
         empty to use the default config/env setting.
-outputs: []
+outputs:
+  - BITRISE_DEVICEFARM_RESULTS_RAW:
+    opts:
+      title: The full output from the device farm run
+      description: |-
+        This is the full results of the run in JSON from AWS Device Farm
+  - BITRISE_DEVICEFARM_RESULTS_SUMMARY:
+    opts:
+      title: A human-readable summary of the results.
+      description: |-
+        A nice summary suitable for feeding into something like a slack message.


### PR DESCRIPTION
This PR ensures the step waits until the run completes or fails in
DeviceFarm, rather than simply scheduling and returning success. This
can take a while depending on the number/type of tests and the number of
devices.

We export the build results, both the raw JSON response from AWS as well
as a nice human-friendly text string. As these are exports, they can be
used by later stages in the Bitrise build process, eg feeding into a
Slack step to return more information about how the build went.

Note that currently this does not include a break down of each
individual job inside the build run. This could be a useful extension
ontop of this work in future.