### PR TITLE
Upload both app & test package in one step

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # Amazon Device Farm Runner
-Deploys app to device farm and starts a test run with a preconfigured test package and device pool.
+Deploys app to device farm and starts a test run with a preconfigured test
+package and device pool. This step includes functionality to upload both the
+application binary and the associated test package file.
 
-This Step requires an Amazon Device Farm registration. To register an account, [click here](https://aws.amazon.com/device-farm/)
-
-Use the [aws-device-farm-file-deploy](https://github.com/peartherapeutics/bitrise-aws-device-farm-file-deploy) step to upload your latest test package (and extra app data if required) before this step runs.
+This Step requires an Amazon Device Farm registration. To register an account,
+[click here](https://aws.amazon.com/device-farm/)
 
 ## How to use this Step
 


### PR DESCRIPTION
Currently the test packages for Devicefarm have to be
uploaded via `bitrise-aws-device-farm-file-deploy` and the application
package is uploaded via this `bitrise-aws-device-farm-runner` step.

However this has two main problems:

1. It opens the build process up to a race condition. If two tests are
   running in parallel with the same test package file name, you could
   end up in a situation where the test package from one build ends up
   getting used for both builds.

2. Usage of this step is quite confusing for new users due to how the
   uploads are handled differently.

This commit fixes the first problem and hopefully improves the second
problem, by having both the test package and application package
uploaded by the runner step and the use of their ARNs to prevent any
contamination of build jobs with the files uploaded for another job.

Note that this commit may break things for users - the test_package_name
param is now expected to point to a file to be uploaded, which may or
may not be true for some users. Possibly we should rename it to
test_package_path, but that would then certainly break it for all
current users which may be more or less desirable - feedback welcome here.

The old `bitrise-aws-device-farm-file-deploy` job will also now be
irrelevant and should be removed from the build workflow - although it
will not cause issues if it does remain other than slower builds due to
wasteful uploading.