### PR TITLE
Add opportunity to filter tests

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -11,6 +11,7 @@ app:
   - BILLING_METHOD: $BILLING_METHOD
   - TEST_PACKAGE_NAME: $TEST_PACKAGE_NAME
   - TEST_TYPE: $TEST_TYPE
+  - FILTER: $FILTER
   - PLATFORM: $PLATFORM
   - IOS_POOL: $IOS_POOL
   - ANDROID_POOL: $ANDROID_POOL
@@ -32,6 +33,7 @@ workflows:
         - billing_method: $BILLING_METHOD
         - test_package_name: $TEST_PACKAGE_NAME
         - test_type: $TEST_TYPE
+        - filter: $FILTER
         - platform: $PLATFORM
         - ios_pool: $IOS_POOL
         - android_pool: $ANDROID_POOL

--- a/step.sh
+++ b/step.sh
@@ -194,7 +194,7 @@ function device_farm_run {
     run_params+=(--device-pool-arn="$device_pool")
     run_params+=(--configuration="{\"billingMethod\": \"${billing_method}\"}")
     run_params+=(--app-arn="$app_arn")
-    run_params+=(--test="{\"type\": \"${test_type}\",\"testPackageArn\": \"${test_package_arn}\",\"parameters\": {\"TestEnvVar\": \"foo\"}}")
+    run_params+=(--test="{\"type\": \"${test_type}\",\"testPackageArn\": \"${test_package_arn}\",,\"filter\": \"${filter}\"\"parameters\": {\"TestEnvVar\": \"foo\"}}")
     run_params+=(--output=json)
 
     if [ ! -z "$run_name_prefix" ]; then

--- a/step.sh
+++ b/step.sh
@@ -289,6 +289,7 @@ fi
 echo_details "* device_farm_project: $device_farm_project"
 echo_details "* test_package_name: $test_package_name"
 echo_details "* test_type: $test_type"
+echo_details "* filter: $filter"
 echo_details "* billing_method: $billing_method"
 echo_details "* platform: $platform"
 echo_details "* ipa_path: $ipa_path"

--- a/step.yml
+++ b/step.yml
@@ -50,7 +50,7 @@ inputs:
     opts:
       title: "Billing Method"
       summary: ""
-      description: "This step specifies the billing methodfor your test run. Use `METERED` for free tier and pay-as-you-go billing, and `UNMETERED` to use [pre-paid device slots](https://docs.aws.amazon.com/devicefarm/latest/developerguide/how-to-purchase-device-slots.html)."
+      description: "This step specifies the billing method for your test run. Use `METERED` for free tier and pay-as-you-go billing, and `UNMETERED` to use [pre-paid device slots](https://docs.aws.amazon.com/devicefarm/latest/developerguide/how-to-purchase-device-slots.html)."
       value_options:
           - "METERED"
           - "UNMETERED"
@@ -70,6 +70,12 @@ inputs:
       summary: ""
       description: "[See the Test.type documentation](http://docs.aws.amazon.com/devicefarm/latest/APIReference/API_Test.html#devicefarm-Type-Test-type)."
       is_required: true
+  - filter: ""
+    opts:
+      title: "Test Filter"
+      summary: ""
+      description: "[This step adds the opportunity to filter your tests. For example com.android.abc.test1."
+      is_required: false
   - platform: "ios+android"
     opts:
       title: "Platform"

--- a/step.yml
+++ b/step.yml
@@ -74,7 +74,7 @@ inputs:
     opts:
       title: "Test Filter"
       summary: ""
-      description: "[This step adds the opportunity to filter your tests. For example com.android.abc.test1."
+      description: "This step adds the opportunity to filter your tests. For example com.android.abc.test1. [See the ScheduleRunTest.filter documentation](https://docs.aws.amazon.com/devicefarm/latest/APIReference/API_ScheduleRunTest.html#devicefarm-Type-ScheduleRunTest-filter)."
       is_required: false
   - platform: "ios+android"
     opts:


### PR DESCRIPTION
With this PR a user can filter tests for his run.

See Docs: http://docs.aws.amazon.com/devicefarm/latest/APIReference/API_ScheduleRunTest.html#devicefarm-Type-ScheduleRunTest-filter

closes https://github.com/peartherapeutics/bitrise-aws-device-farm-runner/issues/39